### PR TITLE
Updates ClientRenderer to render metatags on the client side on initial ...

### DIFF
--- a/lib/client/ClientRenderer.js
+++ b/lib/client/ClientRenderer.js
@@ -6,7 +6,7 @@ var ClientRenderer = {
         var title = view.getTitle ? view.getTitle() : null;
         layout.setTitle(title);
 
-        var shouldRenderMetaTags = layout.updateMetatagsOnClientRender;
+        var shouldRenderMetaTags = requestId === 1 || layout.updateMetatagsOnClientRender;
 
         if (shouldRenderMetaTags) {
             var metatags = view.getMetatags ? view.getMetatags() : null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "brisket",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "description": "Framework for building single page web apps using isomorphic javascript",
     "author": [
         "Wayne Warner",

--- a/spec/client/client/ClientRendererSpec.js
+++ b/spec/client/client/ClientRendererSpec.js
@@ -168,12 +168,28 @@ describe("ClientRenderer", function() {
             };
 
             view.withMetatags(metatags);
-
-            ClientRenderer.render(layout, view);
         });
 
-        it("does NOT set the layout metatags", function() {
-            expect(layout.setMetaTags).not.toHaveBeenCalled();
+        describe("and it is the first request", function() {
+
+            beforeEach(function() {
+                ClientRenderer.render(layout, view, 1);
+            });
+
+            it("sets the layout metatags", function() {
+                expect(layout.setMetaTags).toHaveBeenCalledWith(metatags);
+            });
+        });
+
+        describe("and it is NOT the first request", function() {
+
+            beforeEach(function() {
+                ClientRenderer.render(layout, view, 2);
+            });
+
+            it("does NOT set the layout metatags", function() {
+                expect(layout.setMetaTags).not.toHaveBeenCalled();
+            });
         });
 
     });


### PR DESCRIPTION
...load.  This fixes a bug where metatags are assigned uids on server only, resulting in identification false positives on subsequent request renderings.