### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,21 +113,14 @@ To support IE7, include the snippet above AND the following:
 
 ## Development
 
-Make sure you have `grunt-cli` installed globally. To install:
-
-```shell
-$ npm install -g grunt-cli
-```
-
 Install dependencies:
 ```shell
 $ npm install
 ```
 
 To run the test suite:
-
 ```shell
-$ grunt
+$ npm test
 ```
 
 ## License


### PR DESCRIPTION
It is best practice to include your binaries (e.g. `grunt-cli`) in your `devDependencies` (it already is) and then use NPM scripts to run those binaries (it's already set up for `npm test`). This ensures there aren't any clashes in versions of Grunt CLI (As I've written about: http://www.joezimjs.com/javascript/no-more-global-npm-packages/). It's probably best not to keep pushing bad practices out to the masses, so I've updated the docs to reflect these practices already in place.