### PR TITLE
Add step in documentation to install grunt-cli to run 'grunt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ To install generator-brisket from npm, run:
 npm install -g generator-brisket
 ```
 
+To install grunt-cli from npm, run:
+
+```bash
+npm install -g grunt-cli
+```
+
 Create a directory for your app:
 
 ```bash


### PR DESCRIPTION
Hi, I followed the README and found that to run 'grunt' you need 'grunt-cli' module pre-installed. So just adding that step here in case others who try this don't have grunt-cli pre-installed.

Signed-Off-By: Huy Nguyen <ace321@gmail.com>