### PR TITLE
Brisket should bootstrap the client javascript itself

### DIFF
--- a/docs/brisket.createserver.md
+++ b/docs/brisket.createserver.md
@@ -21,7 +21,10 @@ Here is a valid call to `createServer` with the fewest possible options:
 ```js
 var brisketServer = Brisket.createServer({
     apiHost: 'http://localhost:4000',
-    clientAppRequirePath: 'app/ClientApp'
+    clientAppRequirePath: 'app/ClientApp',
+    environmentConfig: {
+        clientAppUrl: '//www.myapp.com/application.js'
+    }
 });
 ```
 
@@ -42,6 +45,9 @@ var ServerApp = Brisket.ServerApp.extend({
 var brisketServer = Brisket.createServer({
     apiHost: 'http://localhost:4000',
     clientAppRequirePath: 'app/ClientApp',
+    environmentConfig: {
+        clientAppUrl: '//www.myapp.com/application.js'
+    }
 
     ServerApp: ServerApp
 });
@@ -66,7 +72,10 @@ var brisketServer = Brisket.createServer({
     clientAppRequirePath: 'app/ClientApp',
 
     ServerApp: ServerApp,
-    environmentConfig: { some: 'data' }
+    environmentConfig: {
+        some: 'data',
+        clientAppUrl: '//www.myapp.com/application.js'
+    }
 });
 ```
 
@@ -82,6 +91,37 @@ var brisketServer = Brisket.createServer({
     environmentConfig: { appRoot: '/path/to/app/' }
 });
 ```
+
+#### environmentConfig.clientAppUrl
+`environmentConfig.clientAppUrl` is the location of your bundled javascript which Brisket will bootstrap in the browser. Note that this is a required field.
+
+```js
+// On the server
+var brisketServer = Brisket.createServer({
+    apiHost: 'http://localhost:4000',
+    clientAppRequirePath: 'app/ClientApp',
+
+    ServerApp: ServerApp,
+    environmentConfig: {
+        appRoot: '/path/to/app/',
+        clientAppUrl: '//www.myapp.com/application.js'
+    }
+});
+
+#### environmentConfig.startClientAppAsync
+`environmentConfig.startClientAppAsync` if set to a true will bootstrap the client application in the browser asynchronously. The default is synchronous
+
+```js
+var brisketServer = Brisket.createServer({
+    apiHost: 'http://localhost:4000',
+    clientAppRequirePath: 'app/ClientApp',
+    environmentConfig: {
+        clientAppUrl: '//www.myapp.com/application.js',
+        startClientAppAsync: true
+    }
+});
+```
+
 
 #### serverConfig
 `serverConfig` is a hash of key/values that will **ONLY** be available to your ServerApp via the start method. In the ServerApp, `serverConfig` will be available as `options.serverConfig`:

--- a/lib/server/Server.js
+++ b/lib/server/Server.js
@@ -48,6 +48,12 @@ var Server = {
             );
         }
 
+        if (typeof environmentConfig.clientAppUrl !== "string") {
+            throw new Error(
+                "Brisket requires the url of the Client Application javascript to be passed in environmentConfig.clientAppUrl."
+            );
+        }
+
         var serverApp = new ServerAppToUse();
 
         serverConfig.apiHost = apiHost;

--- a/lib/server/ServerRenderer.js
+++ b/lib/server/ServerRenderer.js
@@ -9,7 +9,10 @@ var ServerRenderer = {
     render: function(layout, view, environmentConfig, clientAppRequirePath, serverRequest) {
         var title = view.getTitle ? view.getTitle() : null;
         var metatags = view.getMetatags ? view.getMetatags() : null;
-        var appRoot = environmentConfig ? environmentConfig.appRoot : "";
+        var config = environmentConfig || {};
+        var appRoot = config.appRoot || "";
+        var startClientAppAsync = config.startClientAppAsync;
+        var clientAppUrl = config.clientAppUrl;
 
         layout.renderTitle(title);
         layout.renderMetatags(metatags);
@@ -24,10 +27,11 @@ var ServerRenderer = {
 
         var clientAppStartScript = makeClientAppStartScript(
             clientAppRequirePath,
-            stringifyData(environmentConfig),
+            stringifyData(config),
             escapeClosingSlashes(stringifyData(getBootstrappedDataForRequest()))
         );
 
+        clientAppStartScript = makeBootstrappingLoader(clientAppStartScript, clientAppUrl, startClientAppAsync);
         clientAppStartScript = stripIllegalCharacters(clientAppStartScript);
 
         var html = layout.asHtml();
@@ -59,14 +63,31 @@ function injectScriptAtBottomOfBody(html, script) {
 }
 
 function makeClientAppStartScript(clientAppRequirePath, environmentConfig, bootstrappedData) {
-    return "<script type=\"text/javascript\">\n" +
-        "var ClientApp = require('" + clientAppRequirePath + "');\n" +
+    return "var ClientApp = require('" + clientAppRequirePath + "');\n" +
         "var clientApp = new ClientApp();\n" +
         "clientApp.start({\n" +
         "environmentConfig: " + environmentConfig + ",\n" +
         "bootstrappedData: " + bootstrappedData + "\n" +
-        "});\n" +
-        "</script>";
+    "});";
+}
+
+function makeBootstrappingLoader(scriptBody, clientAppUrl, isAsync) {
+    var loadAsync = isAsync ? "s.async = true;\n" : "";
+
+    return "<script type=\"text/javascript\">\n" +
+        "\"use strict\";" +
+        "(function(d) {\n" +
+        "var s = d.createElement(\"script\");\n" +
+        "s.setAttribute(\"src\", \"" + clientAppUrl + "\");\n" +
+        loadAsync +
+        "function loaded(e) {\n" +
+            scriptBody + "\n" +
+            "s.removeEventListener(\"load\", loaded, false);\n" +
+        "}\n" +
+        "s.addEventListener(\"load\", loaded);\n" +
+        "setTimeout(function() { (d.body || d.head).appendChild(s); }, 0);\n" +
+    "})(document);\n" +
+    "</script>";
 }
 
 function baseTagFrom(appRoot, serverRequest) {

--- a/spec/server/ServerSpec.js
+++ b/spec/server/ServerSpec.js
@@ -113,9 +113,19 @@ describe("Server", function() {
             }));
         }
 
+        function environmentConfigWithoutClientAppUrl() {
+            return Server.create(validConfigWith({
+                environmentConfig: {
+                    appRoot: "/bad/",
+                    clientAppUrl: null
+                }
+            }));
+        }
+
         it("is passed to ServerApp start method", function() {
             environmentConfig = {
-                some: "data"
+                some: "data",
+                clientAppUrl: "application.js"
             };
 
             Server.create(validConfigWith({
@@ -131,6 +141,10 @@ describe("Server", function() {
 
         it("throws an error when appRoot is missing leading slash", function() {
             expect(appRootWithoutLeadingSlash).toThrow();
+        });
+
+        it("throws an error when clientAppUrl is missing", function() {
+            expect(environmentConfigWithoutClientAppUrl).toThrow();
         });
 
     });
@@ -313,12 +327,15 @@ describe("Server", function() {
         return {
             clientAppRequirePath: "app/ClientApp",
             apiHost: API_HOST,
-            ServerApp: ServerApp
+            ServerApp: ServerApp,
+            environmentConfig: {
+                clientAppUrl: "application.js"
+            }
         };
     }
 
     function validConfigWith(customSettings) {
-        return _.extend(validConfig(), customSettings);
+        return _.merge(validConfig(), customSettings);
     }
 
     function objectPassedToServerApp() {


### PR DESCRIPTION
This change breaks the current interface of Brisket by requiring a `clientAppUrl` to be passed down in the environmentConfig. This lets brisket decide how to load the bundled javascript.

Additionally, the user can pass `environmentConfig.startClientAppAsync` to tell brisket to load the bundled javascript asynchronously. By default it will load synchronously.