### PR TITLE
Use named constructors and native forEeach

### DIFF
--- a/lib/application/App.js
+++ b/lib/application/App.js
@@ -6,9 +6,9 @@ var Syncing = require("../modeling/Syncing");
 var noop = require("../util/noop");
 var catchAjaxCallbackExceptions = require("../util/catchAjaxCallbackExceptions");
 
-var App = function() {
+function App() {
     return this.initialize.apply(this, arguments);
-};
+}
 
 App.prototype = {
 

--- a/lib/client/BootstrappedDataService.js
+++ b/lib/client/BootstrappedDataService.js
@@ -3,13 +3,13 @@
 var $ = require("../application/jquery");
 var calculateSyncRequestUrl = require("../util/calculateSyncRequestUrl");
 
-var BootstrappedDataService = function(bootstrappedData) {
+function BootstrappedDataService(bootstrappedData) {
     require("jquery-mockjax")($, window);
 
     this.bootstrappedData = bootstrappedData;
     this.mockjaxIds = {};
     this.checkAlreadyHasData = this.checkAlreadyHasData.bind(this);
-};
+}
 
 BootstrappedDataService.prototype = {
 

--- a/lib/controlling/Controller.js
+++ b/lib/controlling/Controller.js
@@ -2,9 +2,9 @@
 
 var Backbone = require("../application/Backbone");
 
-var BaseController = function() {
+function BaseController() {
     return this.initialize.apply(this, arguments);
-};
+}
 
 BaseController.prototype = {
     initialize: function() {}

--- a/lib/controlling/LayoutDelegate.js
+++ b/lib/controlling/LayoutDelegate.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var _ = require("lodash");
-
-var LayoutDelegate = function() {};
+function LayoutDelegate() {}
 
 LayoutDelegate.prototype = {
 
@@ -33,7 +31,7 @@ LayoutDelegate.from = function(layout) {
     }
 
     layoutDelegate.replayInstructions = function() {
-        _.each(recordedInstructions, function(recordedInstruction) {
+        recordedInstructions.forEach(function(recordedInstruction) {
             var methodName = recordedInstruction.methodName;
             var methodArguments = recordedInstruction.methodArguments;
 

--- a/lib/controlling/Response.js
+++ b/lib/controlling/Response.js
@@ -6,9 +6,9 @@ var isApplicationLink = require("../controlling/isApplicationLink");
 
 var DEFAULT_REDIRECT_APP_ROOT = "";
 
-var Response = function() {
+function Response() {
     return this.initialize.apply(this, arguments);
-};
+}
 
 Response.prototype = {
 

--- a/lib/controlling/Routers.js
+++ b/lib/controlling/Routers.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var RoutersToUse = function(routersConfig) {
+function RoutersToUse(routersConfig) {
     routersConfig = routersConfig || {};
 
     this.CatchAllRouter = routersConfig.CatchAllRouter;
     this.routers = routersConfig.routers;
-};
+}
 
 RoutersToUse.prototype = {
 

--- a/lib/errors/ErrorViews.js
+++ b/lib/errors/ErrorViews.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var ErrorViews = function(mapping) {
+function ErrorViews(mapping) {
     if (!("500" in mapping)) {
         throw new Error("You must specify a 500 error view");
     }
@@ -8,7 +8,7 @@ var ErrorViews = function(mapping) {
     this.UnhandledErrorView = mapping["500"];
 
     this.mapping = mapping;
-};
+}
 
 ErrorViews.prototype = {
 

--- a/lib/modeling/Syncing.js
+++ b/lib/modeling/Syncing.js
@@ -2,7 +2,6 @@
 
 var defer = require("../util/defer");
 var Backbone = require("../application/Backbone");
-var _ = require("lodash");
 
 var middlewares = [];
 
@@ -23,7 +22,7 @@ var Syncing = {
             return data;
         }
 
-        _.each(middlewares, function(middleware) {
+        middlewares.forEach(function(middleware) {
             middleware(method, model, options, renderError);
         });
 

--- a/lib/util/catchAjaxCallbackExceptions.js
+++ b/lib/util/catchAjaxCallbackExceptions.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var Promise = require("bluebird");
-var _ = require("lodash");
 
 var CALLBACK_NAMES = [
     "success",
@@ -10,7 +9,7 @@ var CALLBACK_NAMES = [
 ];
 
 function catchAjaxCallbackExceptions(method, model, options, renderError) {
-    _.each(CALLBACK_NAMES, function(callbackName) {
+    CALLBACK_NAMES.forEach(function(callbackName) {
         var callback = options[callbackName];
 
         if (typeof callback !== "function") {

--- a/lib/util/defer.js
+++ b/lib/util/defer.js
@@ -5,9 +5,9 @@ var Promise = require("bluebird");
 function defer() {
     var resolve, reject;
 
-    var promise = new Promise(function() {
-        resolve = arguments[0];
-        reject = arguments[1];
+    var promise = new Promise(function(resolveArg, rejectArg) {
+        resolve = resolveArg;
+        reject = rejectArg;
     });
 
     return {

--- a/lib/viewing/View.js
+++ b/lib/viewing/View.js
@@ -30,7 +30,7 @@ var View = Backbone.View.extend(_.extend({},
 
 ));
 
-if(Environment.isServer()) {
+if (Environment.isServer()) {
     View.prototype.delegateEvents = function() {
         return this;
     };


### PR DESCRIPTION
Was skimming through brisket trying to understand the code and I noticed that we were using anonymous functions for constructors. In general we should aways prefer named functions as they give better stack traces.

Also, _.each is unnecessary when you know the type is an array and forEach exists.