### PR TITLE
Change to identify links with certain targets as non-application links.

### DIFF
--- a/lib/client/SetupLinksAndPushState.js
+++ b/lib/client/SetupLinksAndPushState.js
@@ -5,6 +5,7 @@ var Backbone = require("../application/Backbone");
 var Url = require("../util/Url");
 var ClientRequest = require("../client/ClientRequest");
 var isApplicationLink = require("../controlling/isApplicationLink");
+var isExternalLinkTarget = require("../controlling/isExternalLinkTarget");
 
 function isNotUsabilityClick(e) { // Allow shift+click for new tabs, etc.
     return !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
@@ -13,8 +14,10 @@ function isNotUsabilityClick(e) { // Allow shift+click for new tabs, etc.
 function routeApplicationLink(e) {
     var $link = $(e.currentTarget);
     var route = $link.attr("href");
+    var target = $link.attr("target");
 
     if (!e.isDefaultPrevented() &&
+        !isExternalLinkTarget(target) &&
         isApplicationLink(route) &&
         isNotUsabilityClick(e)) {
 

--- a/lib/controlling/isExternalLinkTarget.js
+++ b/lib/controlling/isExternalLinkTarget.js
@@ -1,0 +1,35 @@
+"use strict";
+
+/**
+ * Determines whether the target points to a different window, and thus outside of 
+ * the current instance of the application.
+ * @param {String} target The value of the link's target attribute.
+ * @returns {Boolean} true when the target is:
+ *   - "_blank",
+ *   - "_parent", and the parent window isn't the current window,
+ *   - "_top", and the top window isn't the current window.
+ *   - a named window or frame (any other value besides "_self").
+ */
+function isExternalLinkTarget(target) {
+    return target === "_blank" ||
+        (target === "_parent" && window.parent !== window.self) ||
+        (target === "_top" && window.top !== window.self) ||
+        (typeof target === "string" && target !== "_self");
+}
+
+module.exports = isExternalLinkTarget;
+
+// ----------------------------------------------------------------------------
+// Copyright (C) 2015 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/spec/client/client/SetupLinksAndPushStateSpec.js
+++ b/spec/client/client/SetupLinksAndPushStateSpec.js
@@ -129,6 +129,15 @@ describe("SetupLinksAndPushState", function() {
         describe("NOT Backbone navigating to NON application links", function() {
             var $link;
 
+            it("link with target = _blank", function() {
+                $link = $fixture.find("a.applink");
+                $link.attr("target", "_blank");
+
+                $link.click();
+
+                expect(Backbone.history.navigate).not.toHaveBeenCalled();
+            });
+
             it("hash links", function() {
                 $link = $fixture.find("a[href^='#']");
                 expect($link).toExist();

--- a/spec/client/controlling/isExternalLinkTargetSpec.js
+++ b/spec/client/controlling/isExternalLinkTargetSpec.js
@@ -1,0 +1,38 @@
+"use strict";
+
+var isExternalLinkTarget = require("lib/controlling/isExternalLinkTarget");
+
+describe("isExternalLinkTarget", function() {
+
+    it("returns true when target is '_blank'", function() {
+        expect(isExternalLinkTarget("_blank")).toBe(true);
+    });
+
+    it("returns false when target is a named window", function() {
+        expect(isExternalLinkTarget("myWindow")).toBe(true);
+    });
+
+    it("returns false when target is '_self'", function() {
+        expect(isExternalLinkTarget("_self")).toBe(false);
+    });
+
+    it("returns false when target is not passed", function() {
+        expect(isExternalLinkTarget()).toBe(false);
+    });
+
+});
+
+// ----------------------------------------------------------------------------
+// Copyright (C) 2015 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------- END-OF-FILE ----------------------------------


### PR DESCRIPTION
Brisket takes control of all of the links on the page, forcing relative links to open in the same window regardless of the link's _target_ attribute.

Brisket should respect the _target_ attribute, and open links in the appropriate window when the _target_ value is:
- "_blank"
- "_parent", and the parent window isn't the current window
- "_top", and the top window isn't the current window
- a named window or frame (any other string besides "_self").