### PR TITLE
loosen bluebird dependency requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express": "~4.11.0",
     "jquery": ">=1.11.1",
     "jsdom": "~3.1.0",
-    "bluebird": "~2.9.7",
+    "bluebird": "2.x",
     "lodash": "~2.4",
     "qs": "2.3.3",
     "request": "^2.60.0",


### PR DESCRIPTION
our bluebird dependency follows semver so we should loosen are requirement so that consumers of brisket can stay up to date