### PR TITLE
fix broken uid for some child views

### DIFF
--- a/lib/viewing/HasChildViews.js
+++ b/lib/viewing/HasChildViews.js
@@ -11,7 +11,7 @@ var HasChildViews = {
 
     unrenderedChildViews: null,
 
-    totalChildViewsCreated: 0,
+    uidsCreated: 0,
 
     createChildView: function(optionalIdentifier, ChildView) {
         if (typeof optionalIdentifier != "string") {
@@ -26,9 +26,6 @@ var HasChildViews = {
         }
 
         addChildView(parentView, viewRelationship, optionalIdentifier);
-        this.totalChildViewsCreated = this.totalChildViewsCreated + 1;
-
-        viewRelationship.setUid(this.generateChildUid());
 
         return viewRelationship;
     },
@@ -131,9 +128,11 @@ var HasChildViews = {
     },
 
     generateChildUid: function(context) {
+        this.uidsCreated = this.uidsCreated + 1;
+
         var contextId = context ? context + "|" : "";
 
-        return contextId + this.uid + "_" + this.totalChildViewsCreated;
+        return contextId + this.uid + "_" + this.uidsCreated;
     }
 
 };

--- a/lib/viewing/ViewRelationship.js
+++ b/lib/viewing/ViewRelationship.js
@@ -14,17 +14,9 @@ ViewRelationship.prototype = {
     placementStrategy: null,
     uid: null,
 
-    setUid: function(uid) {
-        this.uid = uid;
-    },
-
     instantiateChildView: function() {
         if (!this.childView) {
             this.childView = new this.ChildView(this.options);
-        }
-
-        if (this.childView.setUid && !this.childView.hasValidUid()) {
-            this.childView.setUid(this.uid);
         }
     },
 
@@ -95,6 +87,8 @@ ViewRelationship.prototype = {
         this.destination = destination;
         this.placementStrategy = placementStrategy;
 
+        setUid(this.parentView.generateChildUid(), this.childView);
+
         if (this.parentView.hasNotBeenRendered()) {
             this.parentView.addUnrenderedChildView(this);
             return this;
@@ -155,6 +149,14 @@ function clearParentChildRelationship(relationship) {
 
 function childViewCannotReattach(viewRelationship) {
     return typeof viewRelationship.childView.reattach !== "function";
+}
+
+function setUid(uid, childView) {
+    if (!childView.setUid || childView.hasValidUid()) {
+        return;
+    }
+
+    childView.setUid(uid);
 }
 
 module.exports = ViewRelationship;

--- a/spec/client/client/ClientRendererSpec.js
+++ b/spec/client/client/ClientRendererSpec.js
@@ -104,7 +104,7 @@ describe("ClientRenderer", function() {
         });
 
         it("sets uid to reflect current request and it's creation order", function() {
-            expect(view.setUid).toHaveBeenCalledWith("1|0_0");
+            expect(view.setUid).toHaveBeenCalledWith("1|0_1");
         });
 
     });

--- a/spec/client/viewing/RenderableViewSpec.js
+++ b/spec/client/viewing/RenderableViewSpec.js
@@ -198,19 +198,36 @@ describe("RenderableView", function() {
 
         });
 
-        describe("when instantiating child views", function() {
+        describe("when instantiating child view", function() {
 
             beforeEach(function() {
                 view = new BaseRenderableView();
+                view.setUid("0");
+
+                childView1 = new BaseRenderableView();
+            });
+
+            it("does NOT set uid", function() {
+                view.createChildView(childView1).instantiateChildView();
+                expect(childView1.uid).toBeNull();
+            });
+
+        });
+
+        describe("when rendering child views", function() {
+
+            beforeEach(function() {
+                view = new BaseRenderableView();
+                view.setUid("0");
+
                 childView1 = new BaseRenderableView();
             });
 
             describe("when child view already has a uid", function() {
 
                 beforeEach(function() {
-                    view.setUid("0");
                     childView1.setUid("a valid uid");
-                    view.createChildView(childView1).instantiateChildView();
+                    view.createChildView(childView1).andAppendIt();
                 });
 
                 it("does NOT change the child view's uid", function() {
@@ -222,9 +239,8 @@ describe("RenderableView", function() {
             describe("when child view does NOT have a uid", function() {
 
                 beforeEach(function() {
-                    view.setUid("0");
                     childView1.setUid(null);
-                    view.createChildView(childView1).instantiateChildView();
+                    view.createChildView(childView1).andAppendIt();
                 });
 
                 it("sets the child view's uid", function() {
@@ -234,25 +250,49 @@ describe("RenderableView", function() {
             });
 
             describe("when number of child views goes down and then back up", function() {
-                var uids;
 
                 beforeEach(function() {
-                    uids = [];
                     childView2 = new BaseRenderableView();
                     childView3 = new BaseRenderableView();
                 });
 
                 it("sets the child view to a unique uid", function() {
-                    view.createChildView("childview1", childView1).instantiateChildView();
-                    uids.push(childView1.uid);
-                    view.createChildView("childview2", childView2).instantiateChildView();
-                    uids.push(childView2.uid);
+                    view.createChildView("childview1", childView1).andAppendIt();
+                    view.createChildView("childview2", childView2).andAppendIt();
 
                     view.closeChildView("childview2");
 
-                    view.createChildView("childview3", childView3).instantiateChildView();
+                    view.createChildView("childview3", childView3).andAppendIt();
 
-                    expect(uids).not.toContain(childView3);
+                    expect(childView1.uid).toBe("0_1");
+                    expect(childView3.uid).toBe("0_3");
+                });
+
+            });
+
+            describe("when child multiple child views are created and then all rendered", function() {
+
+                beforeEach(function() {
+                    childView2 = new BaseRenderableView();
+                    childView3 = new BaseRenderableView();
+                });
+
+                it("sets the child view to a unique uid", function() {
+                    view.createChildView("childview1", childView1);
+                    view.createChildView("childview2", childView2);
+                    view.createChildView("childview3", childView3);
+
+                    view.template = function(data) {
+                        return data.views.childview1 +
+                            data.views.childview2 +
+                            data.views.childview3;
+                    };
+
+                    view.render();
+
+                    expect(childView1.uid).toBe("0_1");
+                    expect(childView2.uid).toBe("0_2");
+                    expect(childView3.uid).toBe("0_3");
                 });
 
             });

--- a/spec/server/ServerRendererSpec.js
+++ b/spec/server/ServerRendererSpec.js
@@ -209,7 +209,7 @@ describe("ServerRenderer", function() {
         });
 
         it("sets uid to reflect initial request and it's creation order", function() {
-            expect(view.setUid).toHaveBeenCalledWith("1|0_0");
+            expect(view.setUid).toHaveBeenCalledWith("1|0_1");
         });
 
     });


### PR DESCRIPTION
before this commit, when a child view relationship was set up before the parent view renders i.e. before Renderers set the parent's uid, the viewrelationship was assigned null_X as uid. this fix moves setting of uid from instantiating workflow to rendering workflow.