### PR TITLE
remove custom layout render implementation

### DIFF
--- a/lib/server/ServerRenderer.js
+++ b/lib/server/ServerRenderer.js
@@ -18,8 +18,6 @@ var ServerRenderer = {
         var appRoot = config.appRoot || "";
         var clientAppUrl = config.clientAppUrl;
 
-        layout.runDecorators();
-
         if (view.setUid) {
             view.setUid(layout.generateChildUid(INITIAL_REQUEST_ID));
         }

--- a/lib/viewing/Layout.js
+++ b/lib/viewing/Layout.js
@@ -15,8 +15,6 @@ var Layout = View.extend({
 
     tagName: Environment.isServer() ? "html" : "div",
 
-    isAttached: true,
-
     defaultTitle: "",
 
     content: null,
@@ -41,6 +39,7 @@ var Layout = View.extend({
 
     reattach: function() {
         this.setElement(document.documentElement);
+        this.isAttached = true;
     },
 
     setEnvironmentConfig: function(environmentConfig) {
@@ -77,28 +76,6 @@ var Layout = View.extend({
 
     clearContent: function() {
         this.closeChildView("content");
-    },
-
-    render: function() {
-        this.establishIdentity();
-
-        this.beforeRender();
-        this.generateViewPlaceholders();
-
-        if (Environment.isServer()) {
-            this.renderTemplate();
-            this.renderUnrenderedChildViews();
-        }
-
-        if (Environment.isClient()) {
-            this.reattachUnrenderedChildViews();
-        }
-
-        this.hasBeenRendered = true;
-
-        this.afterRender();
-
-        return this;
     }
 
 });


### PR DESCRIPTION
the render method of layout has not been revisited in a long time. the layout looks like it had a custom server vs browser implementation to render because it used to manage metatags and page title. now that that responsibility has been moved to renderers, the layout can behave like a normal view.