### PR TITLE
always set layout tagName as html

### DIFF
--- a/lib/viewing/Layout.js
+++ b/lib/viewing/Layout.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var View = require("../viewing/View");
-var Environment = require("../environment/Environment");
 var Metatags = require("../metatags/Metatags");
 var noop = require("../util/noop");
 
@@ -13,7 +12,7 @@ var Layout = View.extend({
 
     uid: "0",
 
-    tagName: Environment.isServer() ? "html" : "div",
+    tagName: "html",
 
     defaultTitle: "",
 
@@ -24,6 +23,8 @@ var Layout = View.extend({
     updateMetatagsOnClientRender: false,
 
     fetchData: noop,
+
+    backToNormal: noop,
 
     isSameTypeAs: function(LayoutType) {
         return this.constructor === LayoutType;
@@ -46,10 +47,8 @@ var Layout = View.extend({
         this.environmentConfig = environmentConfig;
     },
 
-    backToNormal: noop,
-
     asHtml: function() {
-        var html = this.tagName === "html" ? this.el.outerHTML : this.el.innerHTML;
+        var html = this.el.outerHTML;
         var htmlTagAttributes = parseHtmlTagAttributesFromRawRenderedHTML(this.rawRenderedHTML);
 
         if (htmlTagAttributes) {


### PR DESCRIPTION
testing layouts is easier if it has a consistent tagName. using "div" tagName isn't necessary on the client side since Layout is attached to html element on the page