### PR TITLE
faster initial route start on client

### DIFF
--- a/lib/client/ClientApp.js
+++ b/lib/client/ClientApp.js
@@ -11,6 +11,25 @@ var ViewsFromServer = require("../viewing/ViewsFromServer");
 
 var ClientApp = App.extend({
 
+    constructor: function() {
+        App.apply(this, arguments);
+
+        var baseStart = this.start;
+
+        /* wawjr3d 5/17/2016
+         * Call finishStart after new ClientApp.start. This is a quick fix
+         * for 0.x race condition where consuming application has ClientApp
+         * that needs to configure the first route but the first route has
+         * already started. This race condition has already been fixed in
+         * brisket 1.x
+         */
+        this.start = function() {
+            baseStart.apply(this, arguments);
+            this.finishStart.apply(this, arguments);
+        };
+
+    },
+
     start: function(options) {
         options = options || {};
         var environmentConfig = options.environmentConfig || {};
@@ -35,24 +54,19 @@ var ClientApp = App.extend({
 
         ViewsFromServer.initialize();
 
-        var clientApp = this;
-
-        /* wawjr3d 3/24/2016
-         * Wrap Backbone history start in set timeout so it moves to back
-         * of run loop. This is a quick fix for 0.x race condition where
-         * consuming application has ClientApp that needs to configure the
-         * first route but the first route has already started. This race
-         * condition has already been fixed in brisket 1.x
-         */
-        setTimeout(function() {
-            SetupLinksAndPushState.start({
-                root: appRoot || "",
-                browserSupportsPushState: clientApp.isPushStateAvailable()
-            });
-        }, 0);
-
         window.Brisket = window.Brisket || {};
         window.Brisket.version = require("../brisket").version;
+    },
+
+    finishStart: function(options) {
+        options = options || {};
+        var environmentConfig = options.environmentConfig || {};
+        var appRoot = environmentConfig.appRoot;
+
+        SetupLinksAndPushState.start({
+            root: appRoot || "",
+            browserSupportsPushState: this.isPushStateAvailable()
+        });
     },
 
     isPushStateAvailable: function() {

--- a/spec/client/client/ClientAppSpec.js
+++ b/spec/client/client/ClientAppSpec.js
@@ -8,16 +8,24 @@ describe("ClientApp", function() {
     var ClientRenderingWorkflow = require("lib/client/ClientRenderingWorkflow");
     var ViewsFromServer = require("lib/viewing/ViewsFromServer");
 
-    var WAIT_FOR_PUSHSTATE_START = 10;
-
     var clientApp;
+    var callOrder;
 
     beforeEach(function() {
+        callOrder = [];
         clientApp = new ClientApp();
 
-        spyOn(SetupLinksAndPushState, "start");
-        spyOn(ClientRenderingWorkflow, "setEnvironmentConfig");
-        spyOn(ViewsFromServer, "initialize");
+        spyOn(SetupLinksAndPushState, "start").and.callFake(function() {
+            callOrder.push("SetupLinksAndPushState.start");
+        });
+
+        spyOn(ClientRenderingWorkflow, "setEnvironmentConfig").and.callFake(function() {
+            callOrder.push("ClientRenderingWorkflow.setEnvironmentConfig");
+        });
+
+        spyOn(ViewsFromServer, "initialize").and.callFake(function() {
+            callOrder.push("ViewsFromServer.initialize");
+        });
     });
 
     it("is a type of App", function() {
@@ -42,11 +50,9 @@ describe("ClientApp", function() {
             clientApp.start();
         });
 
-        it("sets up links and push state", function(done) {
-            setTimeout(function() {
-                expect(SetupLinksAndPushState.start).toHaveBeenCalled();
-                done();
-            }, WAIT_FOR_PUSHSTATE_START);
+        it("sets up links and push state", function() {
+            expect(SetupLinksAndPushState.start).toHaveBeenCalled();
+            expectLastCallToBe("SetupLinksAndPushState.start");
         });
 
         it("initializes views from server", function() {
@@ -84,13 +90,9 @@ describe("ClientApp", function() {
             });
         });
 
-        it("sets up links and push state with appRoot from configuration", function(done) {
-            setTimeout(function() {
-                expect(SetupLinksAndPushState.start.calls.mostRecent().args[0])
-                    .toHaveKeyValue("root", "/appRoot");
-
-                done();
-            }, WAIT_FOR_PUSHSTATE_START);
+        it("sets up links and push state with appRoot from configuration", function() {
+            expect(SetupLinksAndPushState.start.calls.mostRecent().args[0])
+                .toHaveKeyValue("root", "/appRoot");
         });
 
     });
@@ -101,13 +103,9 @@ describe("ClientApp", function() {
             clientApp.start();
         });
 
-        it("sets up links and push state with appRoot from configuration", function(done) {
-            setTimeout(function() {
-                expect(SetupLinksAndPushState.start.calls.mostRecent().args[0])
-                    .toHaveKeyValue("root", "");
-
-                done();
-            }, WAIT_FOR_PUSHSTATE_START);
+        it("sets up links and push state with appRoot from configuration", function() {
+            expect(SetupLinksAndPushState.start.calls.mostRecent().args[0])
+                .toHaveKeyValue("root", "");
         });
 
     });
@@ -119,13 +117,9 @@ describe("ClientApp", function() {
             clientApp.start();
         });
 
-        it("sets up links and push state with appRoot from configuration", function(done) {
-            setTimeout(function() {
-                expect(SetupLinksAndPushState.start.calls.mostRecent().args[0])
-                    .toHaveKeyValue("browserSupportsPushState", true);
-
-                done();
-            }, WAIT_FOR_PUSHSTATE_START);
+        it("sets up links and push state with appRoot from configuration", function() {
+            expect(SetupLinksAndPushState.start.calls.mostRecent().args[0])
+                .toHaveKeyValue("browserSupportsPushState", true);
         });
 
     });
@@ -137,16 +131,33 @@ describe("ClientApp", function() {
             clientApp.start();
         });
 
-        it("sets up links and push state with appRoot from configuration", function(done) {
-            setTimeout(function() {
-                expect(SetupLinksAndPushState.start.calls.mostRecent().args[0])
-                    .toHaveKeyValue("browserSupportsPushState", false);
-
-                done();
-            }, WAIT_FOR_PUSHSTATE_START);
+        it("sets up links and push state with appRoot from configuration", function() {
+            expect(SetupLinksAndPushState.start.calls.mostRecent().args[0])
+                .toHaveKeyValue("browserSupportsPushState", false);
         });
 
     });
+
+    describe("when there is a SubClass of ClientApp", function() {
+        var MyClientApp;
+
+        beforeEach(function() {
+            MyClientApp = ClientApp.extend();
+            clientApp = new MyClientApp();
+        });
+
+        it("sets up links and push state last when it starts", function() {
+            clientApp.start();
+            expect(SetupLinksAndPushState.start).toHaveBeenCalled();
+            expectLastCallToBe("SetupLinksAndPushState.start");
+        });
+
+    });
+
+    function expectLastCallToBe(what) {
+        expect(callOrder.pop()).toBe(what);
+    }
+
 });
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
as a quick fix for making sure setup push state is called last on client app start, we used a settimeout (async). this change still forces setup push state to be called last but now synchronously