### PR TITLE
Support API Aliases with slashes

### DIFF
--- a/lib/server/ServerAjax.js
+++ b/lib/server/ServerAjax.js
@@ -6,21 +6,23 @@ var pathJoin = require("../util/pathJoin");
 var Testable = require("../util/Testable");
 var _ = require("underscore");
 
-var FIND_API_ALIAS = /^\/([^\/]+)(\/.*$)/;
 var originalAjax = Backbone.ajax;
 
 var ServerAjax = {
 
     setup: function(apis) {
+        var availableApis = specificityOrderedApis(apis);
+
         Backbone.ajax = function(options) {
             var originalUrl = options.url;
             var queryParams = options.data;
             var method = options.type ? options.type.toUpperCase() : "GET";
-            var urlParts = originalUrl.match(FIND_API_ALIAS);
-            var apiAlias = urlParts[1];
+
+            var apiAlias = mostSpecificApiMatch(availableApis, originalUrl);
             var apiConfig = apis[apiAlias];
-            var apiPath = urlParts[2];
+            var apiPath = originalUrl.replace(apiAlias + "/", "");
             var url = pathJoin(apiConfig.host, apiPath);
+
             var proxy = apiConfig.proxy || null;
 
             var requestOptions = {
@@ -127,6 +129,20 @@ function addParamsToUrl(url, queryParams) {
 
     return url + separator + params;
 }
+
+var specificityOrderedApis = function(apis) {
+    return Object.keys(apis).sort(function(a, b) {
+        return a.length < b.length;
+    });
+};
+
+var mostSpecificApiMatch = function(availableApis, originalUrl) {
+    for (var i = 0; i < availableApis.length; i++) {
+        if (originalUrl.indexOf(availableApis[i]) === 1) {
+            return availableApis[i];
+        }
+    }
+};
 
 module.exports = ServerAjax;
 

--- a/spec/server/ServerAjaxSpec.js
+++ b/spec/server/ServerAjaxSpec.js
@@ -33,6 +33,44 @@ describe("ServerAjax", function() {
             });
         });
 
+        describe("apis alias has slashes", function() {
+            beforeEach(function() {
+                ServerAjax.setup({
+                    "api": {
+                        host: "http://api.example.com",
+                        proxy: "http://proxy.example.com"
+                    },
+                    "markets/api": {
+                        host: "http://markets.example.com"
+                    }
+                });
+            });
+
+            it("sends request to the correct api", function() {
+                givenApiRequestWillSucceed();
+
+                Backbone.ajax({
+                    url: "/markets/api/path/to/data"
+                });
+
+                thenRequestMadeWith({
+                    url: "http://markets.example.com/path/to/data",
+                    proxy: null,
+                    method: "GET"
+                });
+
+                Backbone.ajax({
+                    url: "/api/path/to/data"
+                });
+
+                thenRequestMadeWith({
+                    url: "http://api.example.com/path/to/data",
+                    proxy: "http://proxy.example.com",
+                    method: "GET"
+                });
+            });
+        });
+
         it("sends request to the correct api", function() {
             givenApiRequestWillSucceed();
 


### PR DESCRIPTION
When an application expects the api to exist at /foo/api, the api alias
also needs to be "foo/api": {host: ...} for it to be found in the list
of available apis passed to createServer.