### PR TITLE
Pass options to layout in rendering workflow

### DIFF
--- a/lib/client/ClientRenderingWorkflow.js
+++ b/lib/client/ClientRenderingWorkflow.js
@@ -30,7 +30,13 @@ var ClientRenderingWorkflow = {
         var isFirstPageLoad = !currentLayout;
         var layoutForRouteIsSameAsCurrent = isFirstPageLoad || currentLayout.isSameTypeAs(LayoutForRoute);
         var shouldUseCurrentLayout = !isFirstPageLoad && layoutForRouteIsSameAsCurrent;
-        var layout = shouldUseCurrentLayout ? currentLayout : new LayoutForRoute();
+
+        // Deprecated: Passing request as options is an intermediate
+        // fix while we plan a better way to get this where it's needed.
+        var layout = shouldUseCurrentLayout ? currentLayout : new LayoutForRoute({
+            request: clientRequest
+        });
+
         var layoutDelegate = LayoutDelegate.from(layout, LayoutForRoute);
 
         layout.setEnvironmentConfig(environmentConfigForAllRequests);

--- a/lib/server/ServerRenderingWorkflow.js
+++ b/lib/server/ServerRenderingWorkflow.js
@@ -20,7 +20,13 @@ var ServerRenderingWorkflow = {
 
         var LayoutForRoute = router.layout;
         var errorViewMapping = router.errorViewMapping;
-        var layout = new LayoutForRoute();
+
+        // Deprecated: Passing request as options is an intermediate
+        // fix while we plan a better way to get this where it's needed.
+        var layout = new LayoutForRoute({
+            request: serverRequest
+        });
+
         var layoutDelegate = LayoutDelegate.from(layout, LayoutForRoute);
 
         layout.setEnvironmentConfig(environmentConfig);

--- a/spec/client/client/ClientRenderingWorkflowSpec.js
+++ b/spec/client/client/ClientRenderingWorkflowSpec.js
@@ -144,6 +144,17 @@ describe("ClientRenderingWorkflow", function() {
 
     });
 
+    it("passes request as option to layout", function(done) {
+        fakeRouter.layout = Layout.extend({
+            initialize: function(options) {
+                expect(options.request.host).toEqual("localhost:8000");
+                done();
+            }
+        });
+
+        handlerReturns = callAugmentedRouterHandler();
+    });
+
     describe("when route has finished", function() {
         var layoutCommandWasExecuted;
         var whenRouteFinished;

--- a/spec/server/ServerRenderingWorkflowSpec.js
+++ b/spec/server/ServerRenderingWorkflowSpec.js
@@ -53,7 +53,8 @@ describe("ServerRenderingWorkflow", function() {
         spyOn(ServerRenderer, "render").and.returnValue("page was rendered");
 
         mockServerRequest = {
-            id: "mockServerRequest"
+            id: "mockServerRequest",
+            host: "mockHost"
         };
 
         mockServerResponse = new ServerResponse();
@@ -73,6 +74,17 @@ describe("ServerRenderingWorkflow", function() {
                 done();
             }
 
+        });
+
+        handlerReturns = callAugmentedRouterHandler();
+    });
+
+    it("passes request as option to layout", function(done) {
+        fakeRouter.layout = Layout.extend({
+            initialize: function(options) {
+                expect(options.request.host).toEqual("mockHost");
+                done();
+            }
         });
 
         handlerReturns = callAugmentedRouterHandler();


### PR DESCRIPTION
In cases where the same app is running two different domains, with
slightly different behavior on each domain, we need to know the hostname
in our Layout. To that end, allow passing the request object as an
option to LayoutForRoute.