### PR TITLE
deprecate Brisket's built in metatag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Now that you have a working app, check out our [Recipes](docs/recipes/README.md)
 * [**Brisket.Events**](docs/brisket.events.md): A proxy to Backbone.Events that exposes a noop on the server to avoid server-side memory leaks.
 * [**Brisket.View**](docs/brisket.view.md): Our version of a Backbone.View that allows support for some of the core features - reattaching views, child view management, memory management, etc.
 * [**Brisket.Layout**](docs/brisket.layout.md): A specialized View that handles meta tags, page title, etc.
-* Brisket.Layout.Metatags: Use this class to make metatags for "pages".
 * [**Brisket.Templating.TemplateAdapter**](docs/brisket.templating.templateadapter.md): Inherit from this to tell Brisket how to render templates.
 * [**Brisket.Templating.StringTemplateAdapter**](docs/brisket.templating.stringtemplateadapter.md): The default template adapter. Set a View's template key to be a string template to get started.
 * Brisket.version: The version of Brisket. On the client, the version can be accessed by `window.Brisket.version`.

--- a/lib/client/ClientRenderer.js
+++ b/lib/client/ClientRenderer.js
@@ -31,7 +31,13 @@ function updateTitle(layout, view, requestId) {
         return;
     }
 
-    document.title = titleForRouteFrom(layout, view);
+    var titleForRoute = titleForRouteFrom(layout, view);
+
+    if (!titleForRoute) {
+        return;
+    }
+
+    document.title = titleForRoute;
 }
 
 function updateMetatags(layout, view, requestId) {

--- a/lib/server/Server.js
+++ b/lib/server/Server.js
@@ -50,6 +50,13 @@ var Server = {
             "https://github.com/bloomberg/brisket/blob/master/docs/brisket.layout.md#using-environment-config-in-template"
         );
 
+        Deprecated.message(
+            "Brisket.Layout.Metatags, Brisket.Layout.prototype.defaultTitle, and Brisket's " +
+            "handling metatags and title tag are deprecated. These features and tools will " +
+            "be removed in the next major release",
+            "https://github.com/bloomberg/brisket/blob/master/docs/brisket.layout.md#setting-a-default-page-title"
+        );
+
         verifyAppRoot(appRoot);
         verifyApis(apis);
 

--- a/lib/viewing/Layout.js
+++ b/lib/viewing/Layout.js
@@ -14,7 +14,7 @@ var Layout = View.extend({
 
     tagName: "html",
 
-    defaultTitle: "",
+    defaultTitle: null,
 
     content: null,
 

--- a/spec/client/client/ClientRendererSpec.js
+++ b/spec/client/client/ClientRendererSpec.js
@@ -244,6 +244,15 @@ describe("ClientRenderer", function() {
                 expect(document.title).toBe("Default Title");
             });
 
+            it("doesn't change title when there is no defaultTitle", function() {
+                whenClientRenders(1);
+                expect(document.title).toBe(originalPageTitle);
+
+                view = new View();
+                whenClientRenders(2);
+                expect(document.title).toBe(originalPageTitle);
+            });
+
         });
 
         describe("when layout template has title tag with attributes", function() {


### PR DESCRIPTION
Brisket has handled changing the title tag, normal metatags, opengraph tags, and link tags. As things get more complex in the meta world, Brisket would have to support complex tags and needs. With the new control Layout controls available, it's much more flexible for the downstream user to handle meta tag management. I'll put a simple implementation of downstream metatag handling into the generator to complement this change.